### PR TITLE
Fix: port 4000 to app.js

### DIFF
--- a/back-end/app.js
+++ b/back-end/app.js
@@ -17,4 +17,8 @@ app.use(express.static(path.join(__dirname, 'public')));
 app.use('/', indexRouter);
 app.use('/users', usersRouter);
 
+app.listen(4000, () => {
+  console.log("Server is running on localhost:4000, you better catch it!");
+});
+
 module.exports = app;


### PR DESCRIPTION
Added a missing port number for the backend. localhost:4000. Using app.listen function.