### PR TITLE
John/rootlayout

### DIFF
--- a/front-end/src/App.jsx
+++ b/front-end/src/App.jsx
@@ -12,12 +12,15 @@ import Example from "./reactQueryExample";
 function App() {
   return (
     <Routes>
+      {/* Public routes  */}
+        <Route path="login" element={<HomePageLogin />} />
+        <Route path="register" element={<Register />} />
+      {/* Protected Routes wrapped by RootLayout  */}
       <Route path="/" element={<RootLayout />}>
-        <Route index element={<HomePageLogin />}></Route>
-        <Route path="dashboard" element={<Dashboard />}></Route>
-        <Route path="complaints" element={<Complaints />}></Route>
-        <Route path="example" element={<Example />}></Route>
-        <Route path="register" element={<Register />}></Route>
+        {/* Default page(index route ) */}
+        <Route index element={<Dashboard />} />
+        <Route path="complaints" element={<Complaints />} />
+        <Route path="example" element={<Example />} />
       </Route>
     </Routes>
   );

--- a/front-end/src/components/SignupForm.jsx
+++ b/front-end/src/components/SignupForm.jsx
@@ -45,7 +45,7 @@ const SignupForm = () => {
     <form
       noValidate
       onSubmit={handleSubmit(onSubmit)}
-      className="bg-gray-100 border border-gray-300 w-md p-8 rounded-xl"
+      className="bg-gray-100 border border-gray-300 max-w-md p-8 rounded-xl"
     >
       <Stack spacing={2}>
         <TextField

--- a/front-end/src/pages/Register.jsx
+++ b/front-end/src/pages/Register.jsx
@@ -24,7 +24,7 @@ const Register = () => {
     <Box sx={{ flexGrow: 1 }}>
       <Grid container>
         <Grid size={{ xs: 12, md: 6 }}>
-          <img src={placeholder} alt="" width={"55%"} />
+          <img src={placeholder} alt="" width={"100%"} />
         </Grid>
         <Grid size={{ xs: 12, md: 6 }}>
           <Typography>Register here!</Typography>

--- a/front-end/src/pages/Register.jsx
+++ b/front-end/src/pages/Register.jsx
@@ -23,10 +23,10 @@ const Register = () => {
   return (
     <Box sx={{ flexGrow: 1 }}>
       <Grid container>
-        <Grid size={{ xs: 6, md: 6 }}>
+        <Grid size={{ xs: 12, md: 6 }}>
           <img src={placeholder} alt="" width={"55%"} />
         </Grid>
-        <Grid size={{ xs: 6, md: 6 }}>
+        <Grid size={{ xs: 12, md: 6 }}>
           <Typography>Register here!</Typography>
           <Typography>add register componet here!</Typography>
           <SignupForm />

--- a/front-end/src/pages/RootLayout.jsx
+++ b/front-end/src/pages/RootLayout.jsx
@@ -6,11 +6,14 @@ import { Outlet } from "react-router";
 
 const RootLayout = () => {
   return (
+    // This setup works but is having some trouble with screen size responsiveness, even when I correct the breakpoints in Register.jsx. I can redo this File
+    // using Material UI grid if I really need to...
     <div className="min-h-screen flex flex-col">
       {/* Header section  */}
+      {/* Mainheader component already has a <header> inside of it  */}
       <MainHeader />
       
-      {/* Main content section  */}
+      {/* Main layout area  */}
       <div className="flex flex-1">
         {/* Side navigation(placeholder for now)  */}
         <aside className="w-64 bg-blue-200 p-4">

--- a/front-end/src/pages/RootLayout.jsx
+++ b/front-end/src/pages/RootLayout.jsx
@@ -16,3 +16,4 @@ const RootLayout = () => {
 };
 
 export default RootLayout;
+

--- a/front-end/src/pages/RootLayout.jsx
+++ b/front-end/src/pages/RootLayout.jsx
@@ -6,12 +6,22 @@ import { Outlet } from "react-router";
 
 const RootLayout = () => {
   return (
-    <>
+    <div className="min-h-screen flex flex-col">
+      {/* Header section  */}
       <MainHeader />
-      <main>
-        <Outlet />
-      </main>
-    </>
+      
+      {/* Main content section  */}
+      <div className="flex flex-1">
+        {/* Side navigation(placeholder for now)  */}
+        <aside className="w-64 bg-blue-200 p-4">
+          <div className="text-center font-semibold">Side nav placeholder</div>
+        </aside>
+        {/* Content for the page  */}
+        <main className="flex-1 p-4">
+          <Outlet />
+        </main>
+      </div>
+    </div>
   );
 };
 


### PR DESCRIPTION
Modified App.jsx and RootLayout.jsx accordingly. The routes are now separated into public and protected(semantically, at least) in App.jsx.

 For the RootLayout.jsx file, I used tailwind for styling the layout. Before getting ready to push I tried resizing the screen on the register page, but it wasn't responsively downsizing. The breakpoints in Register.jsx were:

<Grid size={{ xs: 6, md: 6 }}>

I changed them to:

<Grid size={{ xs: 12, md: 6 }}>

because it should obviously be full width on small screens. This makes it a bit better, but still doesn't shrink the content when resizing the window.

Thus, I'm questioning whether I need to redo the entire RootLayout file that I've been working on for this task to use Material UI grid like other pages like register do instead of Tailwind. If that is the case and I do need to redo this task to use MUI grid instead of tailwind for styling the divs, just don't approve it and let me know. It would be a bit annoying to have to redo it, but it's absolutely not a problem and should be pretty easy if I need to.

As far as the root layout itself, this is what it looks like on a full size screen with no problems:
![Screenshot 2025-03-06 at 12 24 33 AM](https://github.com/user-attachments/assets/9867f8c6-da17-40f2-8e01-7dc68eb21d3d)
