### PR TITLE
Feature/side nav component (#35)

### DIFF
--- a/front-end/src/App.jsx
+++ b/front-end/src/App.jsx
@@ -1,7 +1,8 @@
 import { useState } from "react";
 import reactLogo from "./assets/react.svg";
 import viteLogo from "/vite.svg";
-import "./App.css";
+//commenting out stylesheet since we're not using it and doing this makes it "full screen"
+// import "./App.css";
 import { Routes, Route } from "react-router";
 import HomePageLogin from "./pages/HomePageLogin";
 import Dashboard from "./pages/Dashboard";

--- a/front-end/src/App.jsx
+++ b/front-end/src/App.jsx
@@ -16,7 +16,7 @@ function App() {
       {/* Public routes  */}
         <Route path="login" element={<HomePageLogin />} />
         <Route path="register" element={<Register />} />
-      {/* Protected Routes wrapped by RootLayout  */}
+      {/* Protected Routes wrapped by RootLayout. ALL "details" pages must include "detail" in the path name for navbar state."  */}
       <Route path="/" element={<RootLayout />}>
         {/* Default page(index route ) */}
         <Route index element={<Dashboard />} />

--- a/front-end/src/components/NavItem.jsx
+++ b/front-end/src/components/NavItem.jsx
@@ -23,6 +23,11 @@ import LogoutIcon from '@mui/icons-material/Logout';
 import { NavLink } from 'react-router-dom';
 
 const NavItem = ({ to, text, icon, open }) => {
+    //A helper component for the options in the toolbar
+    //props:
+    //to = page to navigate to
+    //text = text to display by the selection
+    //icon = icon to display from MUI library of icons
     return (
         <ListItem disablePadding sx={{ display: "block" }}>
             <Tooltip title={!open ? text : ""} placement="right">

--- a/front-end/src/components/NavItem.jsx
+++ b/front-end/src/components/NavItem.jsx
@@ -1,25 +1,13 @@
 //This component is just a helper component for the left navigation bar, to keep the code cleaner.
 import React, { useState } from 'react';
 import {
-    Drawer,
-    Box,
-    IconButton,
-    List,
     ListItem,
     ListItemButton,
     ListItemIcon,
     ListItemText,
-    Divider,
     Tooltip
 } from '@mui/material';
 //Icons
-import MenuIcon from '@mui/icons-material/Menu';
-import DashboardIcon from '@mui/icons-material/DashBoard'
-import LockIcon from '@mui/icons-material/Lock';
-import HomeWorkIcon from '@mui/icons-material/HomeWork';
-import ReportIcon from '@mui/icons-material/Report';
-import SettingsIcon from '@mui/icons-material/Settings';
-import LogoutIcon from '@mui/icons-material/Logout';
 import { NavLink } from 'react-router-dom';
 
 const NavItem = ({ to, text, icon, open }) => {

--- a/front-end/src/components/NavItem.jsx
+++ b/front-end/src/components/NavItem.jsx
@@ -1,0 +1,24 @@
+//This component is just a helper component for the left navigation bar, to keep the code cleaner.
+import React, { useState } from 'react';
+import {
+    Drawer,
+    Box,
+    IconButton,
+    List,
+    ListItem,
+    ListItemButton,
+    ListItemIcon,
+    ListItemText,
+    Divider,
+    Tooltip
+} from '@mui/material';
+//Icons
+import MenuIcon from '@mui/icons-material/Menu';
+import DashboardIcon from '@mui/icons-material/DashBoard'
+import LockIcon from '@mui/icons-material/Lock';
+import HomeWorkIcon from '@mui/icons-material/HomeWork';
+import ReportIcon from '@mui/icons-material/Report';
+import SettingsIcon from '@mui/icons-material/Settings';
+import LogoutIcon from '@mui/icons-material/Logout';
+import { NavLink } from 'react-router-dom';
+

--- a/front-end/src/components/NavItem.jsx
+++ b/front-end/src/components/NavItem.jsx
@@ -22,3 +22,37 @@ import SettingsIcon from '@mui/icons-material/Settings';
 import LogoutIcon from '@mui/icons-material/Logout';
 import { NavLink } from 'react-router-dom';
 
+const NavItem = ({ to, text, icon, open }) => {
+    return (
+        <ListItem disablePadding sx={{ display: "block" }}>
+            <Tooltip title={!open ? text : ""} placement="right">
+                <ListItemButton
+                  component={NavLink}
+                  to={to}
+                  sx={{
+                    minHeight: 48,
+                    justifyContent: open ? "initial" : "center",
+                    px: 2.5,
+                    //Highlight the selection if active
+                    "&.active": {
+                      backgroundColor: "rgba(0, 0, 0, 0.88)",
+                    },
+                  }}
+                >
+                    <ListItemIcon
+                      sx={{
+                        minWidth: 0,
+                        mr: open ? 2 : "auto",
+                        justifyContent: "center",
+                      }}
+                    >
+                        {icon}
+                    </ListItemIcon>
+                    {open && <ListItemText primary={text} />}
+                </ListItemButton>
+            </Tooltip>
+        </ListItem>
+    )
+}
+
+export default NavItem;

--- a/front-end/src/components/NavItem.jsx
+++ b/front-end/src/components/NavItem.jsx
@@ -40,7 +40,8 @@ const NavItem = ({ to, text, icon, open }) => {
                     px: 2.5,
                     //Highlight the selection if active
                     "&.active": {
-                      backgroundColor: "rgba(0, 0, 0, 0.88)",
+                      backgroundColor: "#ede7f6",
+                      color: "#4527a0",
                     },
                   }}
                 >

--- a/front-end/src/components/SideNavigation.jsx
+++ b/front-end/src/components/SideNavigation.jsx
@@ -20,6 +20,8 @@ import ReportIcon from '@mui/icons-material/Report';
 import SettingsIcon from '@mui/icons-material/Settings';
 import LogoutIcon from '@mui/icons-material/Logout';
 import { NavLink } from 'react-router-dom';
+//import helper component
+import NavItem from './NavItem';
 
 //fully expanded sidebar width
 const DRAWER_WIDTH = 240;

--- a/front-end/src/components/SideNavigation.jsx
+++ b/front-end/src/components/SideNavigation.jsx
@@ -79,6 +79,35 @@ const SideNavigation = () => {
                   icon={<LockIcon />}
                   open={open}
                 />
+                <NavItem
+                  to="/leases"
+                  text="Leases"
+                  icon={<HomeWorkIcon />}
+                  open={open}
+                />
+                <NavItem
+                  to="/complaints"
+                  text="Complaints"
+                  icon={<ReportIcon />}
+                  open={open}
+                />
+                <NavItem
+                  to="/account-settings"
+                  text="Account Settings"
+                  icon={<SettingsIcon />}
+                  open={open}
+                />
+            </List>
+            <Divider />
+
+            {/* Log out button pinned at bottom */}
+            <List>
+                <NavItem
+                  to="/logout"
+                  text="Log out"
+                  icon={<LogoutIcon />}
+                  open={open}
+                />
             </List>
         </Drawer>
     )

--- a/front-end/src/components/SideNavigation.jsx
+++ b/front-end/src/components/SideNavigation.jsx
@@ -11,3 +11,59 @@ import {
     Divider,
     Tooltip
 } from '@mui/material';
+//Icons
+import MenuIcon from '@mui/icons-material/Menu';
+import DashboardIcon from '@mui/icons-material/DashBoard'
+import LockIcon from '@mui/icons-material/Lock';
+import HomeWorkIcon from '@mui/icons-material/HomeWork';
+import ReportIcon from '@mui/icons-material/Report';
+import SettingsIcon from '@mui/icons-material/Settings';
+import LogoutIcon from '@mui/icons-material/Logout';
+import { NavLink } from 'react-router-dom';
+
+//fully expanded sidebar width
+const DRAWER_WIDTH = 240;
+
+
+const SideNavigation = () => {
+    //open by default for now
+    const [open, setOpen] = useState(true);
+
+    //Handler for toggling expanded or collapsed
+    const handleToggle = () => {
+        setOpen(!open);
+    };
+
+    return (
+        <Drawer
+          variant="permanent"
+          open={open}
+          sx={{
+            width: open ? DRAWER_WIDTH : 64,
+            flexShrink: 0,
+            "& .MuiDrawer-paper": {
+              width: open ? DRAWER_WIDTH : 64,
+              overflowX: "hidden",
+              trainsition: "width 0.3s",
+            },
+          }}
+        >
+            {/* Top area with hamburger icon  */}
+            <Box
+              sx={{
+                display: "flex",
+                alignItems: "center",
+                justifyContent: open ? "flex-end" : "center",
+                p:1
+              }}
+            >
+                <IconButton onClick={handleToggle}>
+                    <MenuIcon />
+                </IconButton>
+            </Box>
+        </Drawer>
+    )
+}
+
+
+export default SideNavigation;

--- a/front-end/src/components/SideNavigation.jsx
+++ b/front-end/src/components/SideNavigation.jsx
@@ -58,6 +58,7 @@ const SideNavigation = () => {
               width: open ? DRAWER_WIDTH : 64,
               overflowX: "hidden",
               transition: "width 0.3s",
+              boxShadow: "2px 5px 10px #4527a0"
             },
           }}
         >
@@ -81,31 +82,31 @@ const SideNavigation = () => {
                 <NavItem
                   to="/"
                   text="Dashboard"
-                  icon={<DashboardIcon />}
+                  icon={<DashboardIcon sx={{ color: "#4527a0" }} />}
                   open={open}
                 />
                 <NavItem
                   to="/access-control"
                   text="Access Control"
-                  icon={<LockIcon />}
+                  icon={<LockIcon sx={{ color: "#4527a0" }} />}
                   open={open}
                 />
                 <NavItem
                   to="/leases"
                   text="Leases"
-                  icon={<HomeWorkIcon />}
+                  icon={<HomeWorkIcon sx={{ color: "#4527a0" }} />}
                   open={open}
                 />
                 <NavItem
                   to="/complaints"
                   text="Complaints"
-                  icon={<ReportIcon />}
+                  icon={<ReportIcon sx={{ color: "#4527a0" }} />}
                   open={open}
                 />
                 <NavItem
                   to="/account-settings"
                   text="Account Settings"
-                  icon={<SettingsIcon />}
+                  icon={<SettingsIcon sx={{ color: "#4527a0" }} />}
                   open={open}
                 />
             </List>
@@ -116,7 +117,7 @@ const SideNavigation = () => {
                 <NavItem
                   to="/logout"
                   text="Log out"
-                  icon={<LogoutIcon />}
+                  icon={<LogoutIcon sx={{ color: "#CA3433" }} />}
                   open={open}
                 />
             </List>

--- a/front-end/src/components/SideNavigation.jsx
+++ b/front-end/src/components/SideNavigation.jsx
@@ -4,22 +4,17 @@ import {
     Box,
     IconButton,
     List,
-    ListItem,
-    ListItemButton,
-    ListItemIcon,
-    ListItemText,
-    Divider,
-    Tooltip
+    Divider
 } from '@mui/material';
 //Icons
 import MenuIcon from '@mui/icons-material/Menu';
-import DashboardIcon from '@mui/icons-material/DashBoard'
+import DashboardIcon from '@mui/icons-material/Dashboard'
 import LockIcon from '@mui/icons-material/Lock';
 import HomeWorkIcon from '@mui/icons-material/HomeWork';
 import ReportIcon from '@mui/icons-material/Report';
 import SettingsIcon from '@mui/icons-material/Settings';
 import LogoutIcon from '@mui/icons-material/Logout';
-import { NavLink, useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
 //import helper component
 import NavItem from './NavItem';
 

--- a/front-end/src/components/SideNavigation.jsx
+++ b/front-end/src/components/SideNavigation.jsx
@@ -1,0 +1,13 @@
+import React, { useState } from 'react';
+import {
+    Drawer,
+    Box,
+    IconButton,
+    List,
+    ListItem,
+    ListItemButton,
+    ListItemIcon,
+    ListItemText,
+    Divider,
+    Tooltip
+} from '@mui/material';

--- a/front-end/src/components/SideNavigation.jsx
+++ b/front-end/src/components/SideNavigation.jsx
@@ -61,6 +61,23 @@ const SideNavigation = () => {
                     <MenuIcon />
                 </IconButton>
             </Box>
+            <Divider />
+
+            {/* Navigation items  */}
+            <List sx={{ flexGrow: 1 }}>
+                <NavItem
+                  to="/"
+                  text="Dashboard"
+                  icon={<DashboardIcon />}
+                  open={open}
+                />
+                <NavItem
+                  to="/access-control"
+                  text="Access Control"
+                  icon={<LockIcon />}
+                  open={open}
+                />
+            </List>
         </Drawer>
     )
 }

--- a/front-end/src/components/SideNavigation.jsx
+++ b/front-end/src/components/SideNavigation.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import {
     Drawer,
     Box,
@@ -19,7 +19,7 @@ import HomeWorkIcon from '@mui/icons-material/HomeWork';
 import ReportIcon from '@mui/icons-material/Report';
 import SettingsIcon from '@mui/icons-material/Settings';
 import LogoutIcon from '@mui/icons-material/Logout';
-import { NavLink } from 'react-router-dom';
+import { NavLink, useLocation } from 'react-router-dom';
 //import helper component
 import NavItem from './NavItem';
 
@@ -28,8 +28,19 @@ const DRAWER_WIDTH = 240;
 
 
 const SideNavigation = () => {
-    //open by default for now
+    //State for open or closed
     const [open, setOpen] = useState(true);
+
+    //get the browser location so we can default to closed if the pathname has "detail" in it
+    const location = useLocation();
+    //effect to run to check for if it should be open or closed
+    useEffect(() => {
+        if (location.pathname.includes("detail")) {
+            setOpen(false);
+        } else {
+            setOpen(true);
+        }
+    }, [location]);
 
     //Handler for toggling expanded or collapsed
     const handleToggle = () => {
@@ -46,7 +57,7 @@ const SideNavigation = () => {
             "& .MuiDrawer-paper": {
               width: open ? DRAWER_WIDTH : 64,
               overflowX: "hidden",
-              trainsition: "width 0.3s",
+              transition: "width 0.3s",
             },
           }}
         >

--- a/front-end/src/pages/RootLayout.jsx
+++ b/front-end/src/pages/RootLayout.jsx
@@ -16,11 +16,9 @@ const RootLayout = () => {
       
       {/* Main layout area  */}
       <div className="flex flex-1">
+        {/* Side nav bar */}
         <SideNavigation />
-        {/* Side navigation(placeholder for now)  */}
-        {/* <aside className="w-64 bg-blue-200 p-4">
-          <div className="text-center font-semibold">Side nav placeholder</div>
-        </aside> */}
+        
         {/* Content for the page  */}
         <main className="flex-1 p-4">
           <Outlet />

--- a/front-end/src/pages/RootLayout.jsx
+++ b/front-end/src/pages/RootLayout.jsx
@@ -2,6 +2,7 @@ import React from "react";
 
 import Navbar from "../components/Navbar";
 import MainHeader from "../components/MainHeader";
+import SideNavigation from "../components/SideNavigation";
 import { Outlet } from "react-router";
 
 const RootLayout = () => {
@@ -15,10 +16,11 @@ const RootLayout = () => {
       
       {/* Main layout area  */}
       <div className="flex flex-1">
+        <SideNavigation />
         {/* Side navigation(placeholder for now)  */}
-        <aside className="w-64 bg-blue-200 p-4">
+        {/* <aside className="w-64 bg-blue-200 p-4">
           <div className="text-center font-semibold">Side nav placeholder</div>
-        </aside>
+        </aside> */}
         {/* Content for the page  */}
         <main className="flex-1 p-4">
           <Outlet />


### PR DESCRIPTION
Sidebar has been implemented with a material UI drawer for its backbone, with some additional code added on top of it, including a NavItem helper component. It has each of the requested menu items, with their names and icons when open or just the icon when it's closed. There is also a log out button at the bottom. It will default to closed on any path with "detail" in the name. They are all functional navigational links to the appropriate paths(some of which haven't been implemented yet). It opens with a .3s transition. The text sometimes jumps for a second when opening, there are ways to fix this but I'd have to redo a lot of it so we should see if it's really a problem first. The selected item stays highlighted

I got a bit creative with the styling at the end, and implemented purple icons, a light purple highlight, and a purple box shadow(maybe a color theme for the app as a whole?) The logout icon I made red. If the team doesn't like those choices I can easily change it!

This is with App.css commented out because I think we're going to remove it anyways. Now the app is full screen.

![Screenshot 2025-03-07 at 12 18 00 AM](https://github.com/user-attachments/assets/7b622ee3-333a-4723-b848-856eb171f65a)
