### PR TITLE
Switched timestamp to date_submitted

### DIFF
--- a/front-end/src/components/ComplaintCard.jsx
+++ b/front-end/src/components/ComplaintCard.jsx
@@ -33,14 +33,14 @@ const ComplaintCard = ({ complaint }) => {
     const {
         id,
         complaint_type,
-        timestamp,
+        date_submitted,
         description,
         status,
     } = complaint;
 
     const iconElement = complaintTypeIcons[complaint_type] || <HelpOutlineIcon fontSize='small' sx={{ color: "gray" }} />;
 
-    const dateString = new Date(timestamp).toLocaleDateString("en-US", {
+    const dateString = new Date(date_submitted).toLocaleDateString("en-US", {
         month: "long",
         day: "numeric",
         year: "numeric",


### PR DESCRIPTION
The "timestamp" variable in the original code has been changed to date_submitted to match the database. Before this fix, "invalid date" was being displayed.