### PR TITLE
Fixed broken formatting

### DIFF
--- a/front-end/src/components/aptdetails/Details.jsx
+++ b/front-end/src/components/aptdetails/Details.jsx
@@ -16,10 +16,6 @@ const Details = ({ apartmentData }) => {
         <CardContent className="p-4 space-y-3 text-center text-xl-1 font-semi-bold text-gray-800">
           <Grid2>
             <h2>
-              <strong>Layout: </strong>
-              {floorPlanName}
-            </h2>
-            <h2>
               <strong>Sq. Ft: </strong>
               {squareFootage}
             </h2>

--- a/front-end/src/components/aptdetails/Features.jsx
+++ b/front-end/src/components/aptdetails/Features.jsx
@@ -59,7 +59,7 @@ const Features = ({ apartmentData }) => {
           Features
         </Typography>
         {!isEditing && (
-          <Button variant="outlined" onClick={handleEdit}>
+          <Button variant="outlined" onClick={handleEdit} sx={{ mt: 2 }}>
             Add/Remove Features <EditIcon />
           </Button>
         )}

--- a/front-end/src/components/aptdetails/Hero.jsx
+++ b/front-end/src/components/aptdetails/Hero.jsx
@@ -64,7 +64,7 @@ const Hero = ({ apartmentData }) => {
         </Typography>
         <CardContent className="text-xl-1 font-semi-bold text-gray-800">
           <Grid2 container>
-            <Grid2 size={{ xs: 12, md: 5 }} sx={{ p: 5, position: "relative" }}>
+            <Grid2 size={{ xs: 12, md: 5 }} sx={{ p: 2, position: "relative" }}>
               <Typography variant="h5" sx={{ fontWeight: "bold" }}>
                 Apartment {apartmentNumber}
               </Typography>
@@ -75,7 +75,7 @@ const Hero = ({ apartmentData }) => {
               </p>
               <p>{address4}</p>
             </Grid2>
-            <Grid2 size={{ xs: 12, md: 5 }} sx={{ p: 2, mt: 3 }}>
+            <Grid2 size={{ xs: 12, md: 5 }} sx={{ p: 2 }}>
               <Typography variant="h6" sx={{ mb: 1 }}>
                 <strong>Status: </strong>
                 {leaseId ? (

--- a/front-end/src/components/aptdetails/Hero.jsx
+++ b/front-end/src/components/aptdetails/Hero.jsx
@@ -62,7 +62,7 @@ const Hero = ({ apartmentData }) => {
         >
           Details
         </Typography>
-        <CardContent className="p-4 space-y-3 text-center text-xl-1 font-semi-bold text-gray-800">
+        <CardContent className="text-xl-1 font-semi-bold text-gray-800">
           <Grid2 container>
             <Grid2 size={{ xs: 12, md: 5 }} sx={{ p: 5, position: "relative" }}>
               <Typography variant="h5" sx={{ fontWeight: "bold" }}>
@@ -151,108 +151,6 @@ const Hero = ({ apartmentData }) => {
       </Card>
     </React.Fragment>
   );
-  {
-    /* return (
-    <Box>
-      <Box
-        sx={{
-          width: "100%",
-          border: "10px ridge rgb(157, 127, 246)",
-          borderRadius: 5,
-          overflow: "hidden",
-        }}
-      >
-        <Grid2 container>
-          <Grid2 size={{ xs: 12, md: 5 }} sx={{ p: 2, position: "relative" }}>
-
-            <Typography variant="h4" sx={{ fontWeight: "bold" }}>
-              Apartment {apartmentNumber}
-            </Typography>
-
-            <Typography variant="h6">{address1}</Typography>
-            <Typography variant="h6">
-              {address2}, {address3}
-            </Typography>
-            <Typography variant="h6">{address4}</Typography>
-          </Grid2>
-
-          <Grid2 size={{ xs: 12, md: 5 }} sx={{ p: 2 }}>
-            <Typography variant="h5" sx={{ mb: 1 }}>
-              <strong>Status: </strong>
-              {leaseId ? (
-                <Link to={`/lease-details/${leaseId}`} className="underline">
-                  <span style={{ color: statusColor }}>{leaseStatus}</span>
-                </Link>
-              ) : (
-                <span style={{ color: statusColor }}>{leaseStatus}</span>
-              )}
-            </Typography>
-
-            <Typography variant="h5" sx={{ mb: 1 }}>
-              <strong>Lease Expires: </strong>
-              {leaseEndDate ? (
-                <span style={{ color: leaseExpirationColor }}>
-                  {leaseEndDate}
-                </span>
-              ) : (
-                <span style={{ color: "black" }}>N/A</span>
-              )}
-            </Typography>
-
-            <Typography variant="h5" sx={{ mb: 1 }}>
-              <strong>Current Occupant: </strong>
-              {tenantId ? (
-                <Link to={`/tenant-details/${tenantId}`} className="underline">
-                  <span style={{ color: "green" }}>{tenantName}</span>
-                </Link>
-              ) : (
-                <span style={{ color: "black" }}>N/A</span>
-              )}
-            </Typography>
-          </Grid2>
-
-          <Grid2
-            size={{ xs: 12, md: 2 }}
-            sx={{
-              p: 2,
-              display: "flex",
-              alignItems: "center",
-            }}
-          >
-            <img
-              src={floorPlanImg}
-              alt="Floor Plan Diagram"
-              style={{
-                maxWidth: "160px",
-                maxHeight: "150px",
-                objectFit: "contain",
-              }}
-            />
-
-            <IconButton
-              aria-label="Zoom Floor Plan"
-              onClick={() => setIsModalOpen(true)}
-            >
-              <AddCircleOutlineIcon sx={{ color: "green" }} />
-            </IconButton>
-          </Grid2>
-        </Grid2>
-      </Box>
-
-      <Dialog open={isModalOpen} onClose={() => setIsModalOpen(false)}>
-        <img
-          src={floorPlanImg}
-          alt="Floor Plan Diagram(large)"
-          style={{
-            maxWidth: "80vw",
-            maxHeight: "80vh",
-            objectFit: "contain",
-          }}
-        />
-      </Dialog>
-    </Box>
-  ); */
-  }
 };
 
 export default Hero;

--- a/front-end/src/components/aptdetails/Hero.jsx
+++ b/front-end/src/components/aptdetails/Hero.jsx
@@ -55,7 +55,7 @@ const Hero = ({ apartmentData }) => {
 
   return (
     <React.Fragment>
-      <Card sx={{ height: 300 }}>
+      <Card sx={{ height: "auto" }}>
         <Typography
           className=" text-white text-center py-3 text-lg font-semibold rounded-t-lg"
           bgcolor={"#206129"}

--- a/front-end/src/components/aptdetails/Notes.jsx
+++ b/front-end/src/components/aptdetails/Notes.jsx
@@ -54,7 +54,7 @@ const Notes = ({ apartmentData }) => {
           Notes
         </Typography>
         {!isEditing && (
-          <Button variant="outlined" color="primary" onClick={handleEdit}>
+          <Button variant="outlined" color="primary" onClick={handleEdit} sx={{ mt: 2 }}>
             Modify Notes <EditIcon />
           </Button>
         )}


### PR DESCRIPTION
There was an error because the layout was still trying to be rendered on the details component. There was also no top margin between the edit buttons and the card titles, it looks a lot better now, see before and after. Additionally, the styling was broken and shifted everything way to the right in the hero with a bunch of tailwind classes. See before and after. Finally, the entire old version of the hero file was just commented out. I removed it. It adapts the new theme, but looks like it did before layout wise.
Before:
![Screenshot 2025-03-26 at 5 54 32 PM](https://github.com/user-attachments/assets/fe461827-985d-46ff-84df-20fc984edd54)

![Screenshot 2025-03-26 at 5 54 52 PM](https://github.com/user-attachments/assets/c10dcba5-39e2-4627-bedc-5b5ca7c4002b)
